### PR TITLE
[mac] venv.sh + start.sh (closes #2)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# start.sh — activate the venv and launch the Gradio app.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -f .venv/bin/activate ]; then
+    echo "Run ./install.sh first." >&2
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source .venv/bin/activate
+
+exec python CoppyLora_webUI.py "$@"

--- a/venv.sh
+++ b/venv.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# venv.sh — drop into a subshell with the project venv activated.
+# Mac equivalent of venv.cmd.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -f .venv/bin/activate ]; then
+    echo "Run ./install.sh first." >&2
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source .venv/bin/activate
+
+exec "${SHELL:-/bin/zsh}"


### PR DESCRIPTION
Closes #2.

Two small shell scripts at the repo root for Mac users. Windows `venv.cmd` / `build.cmd` are left untouched.

- `venv.sh` — `source .venv/bin/activate` then `exec $SHELL` for an interactive subshell.
- `start.sh` — `source .venv/bin/activate` then `exec python CoppyLora_webUI.py`.

Both:
- `set -euo pipefail`
- `cd "$(dirname "$0")"` so they can be invoked from any directory
- bail out with `Run ./install.sh first.` if `.venv/bin/activate` is missing
- pass through args (`start.sh "$@"`)
- syntax-checked with `bash -n`

Out of scope: a `build.sh` PyInstaller equivalent — `.app` bundling deferred to v2 per the tracking issue (#7).
