### PR TITLE
[mac] Auto-detect device (MPS > CUDA > CPU) in CoppyLora_webUI.py (closes #3)

### DIFF
--- a/CoppyLora_webUI.py
+++ b/CoppyLora_webUI.py
@@ -9,6 +9,23 @@ import socket
 import webbrowser
 import threading
 import toml
+import torch
+
+
+# Auto-detect the best available device:
+#   MPS (Apple Silicon) > CUDA (NVIDIA) > CPU.
+# MPS is checked first so that on a hypothetical Mac with an external CUDA
+# device the Mac-native backend wins; on Linux/Windows machines without MPS
+# the check falls through to CUDA.
+def _default_device() -> str:
+    if torch.backends.mps.is_available():
+        return "mps"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+DEFAULT_DEVICE = _default_device()
 
 
 # ログでエラーが出るので、念のため環境変数を設定
@@ -307,7 +324,7 @@ def simple_train(base_model, input_image_path, lora_name, mode_inputs, character
         "new_conv_rank": 16,
         "save_to": train_lora,
         "model": merge_lora,
-        "device": "cuda",
+        "device": DEFAULT_DEVICE,
         "verbose": "store_true",
         "dynamic_param": None,
         "dynamic_method": None,
@@ -495,7 +512,7 @@ def detail_train(base_model, detail_lora_name, detail_base_img_path, detail_base
         "new_conv_rank": 16,
         "save_to": train_lora,
         "model": merge_lora,
-        "device": "cuda",
+        "device": DEFAULT_DEVICE,
         "verbose": "store_true",
         "dynamic_param": None,
         "dynamic_method": None,


### PR DESCRIPTION
Closes #3.

## Diff (3 small chunks)
- Add `import torch` and a `_default_device()` helper near the top of the file.
- Define `DEFAULT_DEVICE` once.
- Replace the two `"device": "cuda"` literals (in `simple_train` and `detail_train`, both inside the `args_dict` for `resize.resize(args)`) with `DEFAULT_DEVICE`.

That's it. Gradio UI, training calls, all paths unchanged.

## Verification
- `python3 -m py_compile CoppyLora_webUI.py` — parses OK.
- `grep -nE '"device":\s*"cuda"' CoppyLora_webUI.py` — no matches remain.
- The lone remaining `"cuda"` string in the file is the literal returned by `_default_device()` when CUDA is the chosen backend — by design.

## Order of checks (MPS first, CUDA second)
On Mac there is no CUDA, so the first branch wins. On Linux/Windows there is no MPS (`torch.backends.mps.is_available()` returns False), so the CUDA branch wins. CPU is the universal fallback.
