### PR TITLE
[mac] install.sh: pin gradio/pydantic/fastapi/starlette (fixes #14)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,15 @@ uv pip install numpy==1.26.4
 
 echo "Installing additional packages..."
 uv pip install wandb==0.17.3
-uv pip install gradio==4.3.0
+# Upstream pin (gradio==4.3.0) was Nov 2023 and is incompatible with current
+# starlette/pydantic releases. We bump to gradio 4.44.1 (Sep 2024) and pin its
+# contemporaries explicitly, since unpinned installs resolve to incompatible
+# 2025+ versions and fail at first request:
+#   - pydantic >= 2.10 emits additionalProperties: True (bool); gradio_client's
+#     get_type() does `if "const" in schema` and crashes on bool.
+#   - starlette >= 0.40 / fastapi >= 0.116 changed TemplateResponse to require
+#     (request, name, ctx); gradio 4.44.1 still calls (name, ctx).
+uv pip install "gradio==4.44.1" "pydantic<2.10" "fastapi==0.115.0" "starlette==0.38.6"
 uv pip install huggingface-hub==0.34.3
 uv pip install onnx==1.15.0 onnxruntime==1.17.1
 uv pip install toml


### PR DESCRIPTION
Closes #14.

## Why

Upstream's `gradio==4.3.0` (Nov 2023) is incompatible with current pydantic 2.10+ and starlette/fastapi 0.40+/0.116+ releases. Without pinning, fresh installs crash at the first HTTP request with one of:

- `TypeError: argument of type 'bool' is not iterable` — `gradio_client.utils.get_type` does `"const" in schema` on a bool, because pydantic ≥ 2.10 emits `additionalProperties: True` (literal bool, not dict).
- `TypeError: unhashable type: 'dict'` — starlette ≥ 0.40 changed `TemplateResponse(name, ctx)` to `TemplateResponse(request, name, ctx)`. Gradio 4.x still calls the old signature, so the dict reaches Jinja2's `LRUCache` as a key.

Both surface as the misleading downstream symptom `ValueError: When localhost is not accessible…`, because Gradio's localhost self-check is what triggers the upstream crash.

## What

Bump `gradio` to 4.44.1 (Sep 2024) and pin its contemporaries:

```bash
uv pip install "gradio==4.44.1" "pydantic<2.10" "fastapi==0.115.0" "starlette==0.38.6"
```

Inline comment in `install.sh` documents *why* each pin exists, so a future bump doesn't silently regress.

## Verification

Tested locally on M4 Pro / macOS 26.0.1:

```
$ ./install.sh
…install summary, MPS available: True…

$ ./start.sh
Running on local URL:  http://0.0.0.0:7861
$ curl -o /dev/null -w '%{http_code}' http://127.0.0.1:7861/
200
```

No tracebacks. Browser opens.

## Test plan

- [x] Gradio launches without TypeError on a venv created with the pinned deps
- [x] HTTP 200 on the local URL
- [ ] SimpleTrain smoke test (issue #6 — manual on M4 Pro)
- [ ] DetailTrain smoke test (issue #6 — manual on M4 Pro)