### PR TITLE
[mac-v2] start.sh: add MPS memory env vars + CPU fallback

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -13,4 +13,14 @@ fi
 # shellcheck source=/dev/null
 source .venv/bin/activate
 
+# Mac (MPS) memory tuning. Disable the default upper watermark (which assumes
+# isolated GPU memory) and let torch.mps.set_per_process_memory_fraction() in
+# the Python process be the single source of truth for the MPS cap.
+export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
+export PYTORCH_MPS_LOW_WATERMARK_RATIO=0.3
+
+# Allow PyTorch to fall back to CPU for ops not yet implemented on MPS.
+# Avoids hard-failing mid-training on a single missing kernel.
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+
 exec python CoppyLora_webUI.py "$@"


### PR DESCRIPTION
Closes #16.

## Summary

Three env vars exported before `exec python`:

- `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0` — disable upper watermark (which assumes isolated GPU memory).
- `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.3` — release cached blocks back to the OS more aggressively.
- `PYTORCH_ENABLE_MPS_FALLBACK=1` — let MPS-missing ops fall back to CPU instead of aborting.

Pairs with #17 (Python-side `set_per_process_memory_fraction(0.80)`), which becomes the single source of truth for the MPS cap once `HIGH_WATERMARK_RATIO` is disabled.

## Test plan

- [x] `bash -n start.sh` passes.
- [ ] `./start.sh` launches Gradio cleanly on M4 Pro.
- [ ] `os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] == "0.0"` inside the Python process.
- [ ] Full smoke test in #22.
