### PR TITLE
[mac-v2] CoppyLora_webUI.py: cap MPS at 80% of unified memory

### DIFF
--- a/CoppyLora_webUI.py
+++ b/CoppyLora_webUI.py
@@ -28,6 +28,18 @@ def _default_device() -> str:
 DEFAULT_DEVICE = _default_device()
 
 
+# Reserve ~20% of unified memory for the OS / window server / browser.
+# Without this, MPS will happily request 90%+ of system RAM, the OS pages
+# WindowServer to swap, and step time blows up from ~10 s/iter to >100 s/iter.
+# Calibrated for 24 GB M4 Pro; harmless on machines with more RAM.
+if DEFAULT_DEVICE == "mps":
+    try:
+        torch.mps.set_per_process_memory_fraction(0.80)
+    except (AttributeError, RuntimeError):
+        # PyTorch <2.1 lacks this API; env vars in start.sh still cap memory.
+        pass
+
+
 # ログでエラーが出るので、念のため環境変数を設定
 os.environ['TERM'] = 'dumb'
 


### PR DESCRIPTION
Closes #17.

## Summary

`torch.mps.set_per_process_memory_fraction(0.80)` reserves ~20% of unified memory for the OS / WindowServer / browser. Pairs with #16's `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0`, which makes this Python-side fraction the single source of truth for the MPS cap.

## Why

On Apple Silicon the GPU shares RAM with everything. Without a cap, MPS requests 90%+ of system memory, the OS pages WindowServer to swap, step time blows up from ~10 s/iter to >100 s/iter (observed in v1, transcript `tasks/brslaqkrf.output:158-162`).

## Test plan

- [x] AST parses.
- [ ] App launches on M4 Pro without error.
- [ ] `torch.mps.driver_allocated_memory()` after launch shows allocator respects the 0.80 cap.
- [ ] Smoke test in #22.

## Edge cases handled

- `DEFAULT_DEVICE != "mps"` → no-op (CUDA / CPU paths unaffected).
- PyTorch <2.1 lacks the API → `AttributeError` caught silently, #16 env vars still cap memory.
