### PR TITLE
[mac-v2] Pin PyTorch >=2.6 in install.sh (#20)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,10 @@ source .venv/bin/activate
 # Do NOT pass --index-url here; the cu128 channel has no Apple Silicon wheels.
 
 echo "Installing PyTorch (stable, with MPS)..."
-uv pip install torch torchvision torchaudio
+# PyTorch 2.5.x has a documented MPS memory regression (~50% larger working
+# set vs 2.4 / 2.6+). Pin >=2.6 so new installs can't land there.
+# 2.11.0 is the verified baseline as of v1.1.0-mac.
+uv pip install "torch>=2.6" "torchvision>=0.21" torchaudio
 
 # ---------------------------------------------------------------------------
 # 4. Clone sd-scripts at the upstream-pinned commit


### PR DESCRIPTION
## Summary
- Pins PyTorch to `>=2.6` (and torchvision to `>=0.21`) in `install.sh` so fresh installs can't accidentally land on 2.5.x.
- 2.5.x has a documented MPS memory regression (~50% larger working set vs 2.4 / 2.6+).
- 2.11.0 is the verified baseline as of v1.1.0-mac.

## Quality firewall
No training-math change. Pure dependency floor pin — affects only fresh `./install.sh` runs.

## Test plan
- [ ] Run `./install.sh` in a clean directory; verify `python -c "import torch; print(torch.__version__)"` reports `>=2.6`.
- [ ] Existing `.venv` (currently 2.11.0) is unaffected.

Closes #20.