### PR TITLE
[mac-v2.1] Swap Mac default to Adafactor; AdamW becomes opt-in

### DIFF
--- a/README_MAC.md
+++ b/README_MAC.md
@@ -110,27 +110,39 @@ Mac unified memory is shared with WindowServer, your browser, every Electron app
 - Quit Slack, Discord, Telegram, Spotify, Notion, and any other Electron app.
 - Close all browser tabs except the Gradio one. Many-tabbed Chrome / Comet / Safari can easily hold 4–8 GB.
 - (16 GB Macs only, recommended) Log out and back in before the first run. WindowServer's working set grows over time and a fresh login reclaims it.
-- Open Activity Monitor → Memory tab. Watch **Swap Used** while training. >2 GB sustained means you're swapping — quit more apps or switch to `config_lowmem.toml`.
+- Open Activity Monitor → Memory tab. Watch **Swap Used** while training. >2 GB sustained means you're swapping — quit more apps.
 
 The launcher (`start.sh`) automatically sets `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0`, `PYTORCH_MPS_LOW_WATERMARK_RATIO=0.3`, and `PYTORCH_ENABLE_MPS_FALLBACK=1`, and the Python process reserves ~20% of RAM for the OS via `torch.mps.set_per_process_memory_fraction(0.80)`. These cap MPS allocations so the OS doesn't get paged out — but they only help if you also keep the OS side of the budget clean.
 
 ---
 
-## 6. Memory tuning (if you still hit MPS out-of-memory)
+## 6. The two configs
 
-If section 5's hygiene checklist isn't enough, swap to the included low-memory profile:
+The repo ships two SDXL training configs:
+
+| File | Optimizer | Batch | Best for |
+| --- | --- | --- | --- |
+| `config.toml` (default) | Adafactor + `fused_backward_pass` | 1 | Every Mac. The launcher reads this. |
+| `config_adamw_full.toml` | AdamW (32-bit) | 2 | Reference profile. **Will OOM on every <64 GB Mac and probably most 64 GB Macs too** — Apple's `recommendedMaxWorkingSetSize` caps MPS at ~17.7 GiB regardless of how much RAM you have, and AdamW32 + fp32 + batch=2 needs ~18 GiB. Kept for transparency, not for daily use. |
+
+To use the AdamW reference profile on a Mac Studio with enough headroom:
 
 ```bash
-cp config_lowmem.toml config.toml      # or symlink it; back up config.toml first
+cp config.toml config.toml.adafactor-backup
+cp config_adamw_full.toml config.toml
 ./start.sh
 ```
 
-`config_lowmem.toml` switches to **Adafactor + `fused_backward_pass`** (cuts optimizer-state memory ~50% vs AdamW) and `train_batch_size = 1`. Convergence per step is slightly slower but total wall-clock often comes out faster on memory-tight Macs because you stop swapping.
+To restore the default afterward:
 
-If even that isn't enough, edit `config.toml` (or `config_lowmem.toml`) further:
+```bash
+cp config.toml.adafactor-backup config.toml
+```
+
+If even the default Adafactor profile runs out of memory:
 
 1. **Drop resolution**: `resolution = "768,768"` (still SDXL-compatible via bucketing).
-2. Already at `train_batch_size = 1` in lowmem; can't go lower.
+2. `train_batch_size` is already 1; can't go lower.
 
 ---
 
@@ -138,22 +150,28 @@ If even that isn't enough, edit `config.toml` (or `config_lowmem.toml`) further:
 
 Expected sustained step times on a clean M4 Pro 24 GB (Activity Monitor + Safari only, 1024×1024, `network_dim = 16`):
 
-| Profile               | Peak memory | Step time   | 500 steps |
-| --------------------- | ----------- | ----------- | --------- |
-| `config.toml` (AdamW) | ~18 GB      | 8–15 s/iter | ~75 min   |
-| `config_lowmem.toml`  | ~12 GB      | 6–10 s/iter | ~55 min   |
+| Config                      | Peak memory | Step time   | 500 steps | Status on 24 GB Mac |
+| --------------------------- | ----------- | ----------- | --------- | --- |
+| `config.toml` (Adafactor)   | ~12 GB      | 6–10 s/iter | ~55 min   | ✅ default — fits |
+| `config_adamw_full.toml`    | ~18 GB      | 8–15 s/iter | ~75 min   | ❌ OOMs at VAE caching (14.2 GiB cap) |
 
 DetailTrain runs the training step twice (base + kari), so roughly **2× SimpleTrain wall-clock**.
 
 The very first iteration is slow — Metal kernels compile on first use. Subsequent iterations run at the steady-state rate.
 
-**If you see step times >30 s/iter sustained, you are swapping.** That is a system-hygiene problem, not a platform limit. Re-read section 5.
+**If you see step times >30 s/iter sustained, you are swapping.** That is a system-hygiene problem (section 5), not a platform limit.
 
-### Why these differ from Windows
+### Why the Mac default isn't AdamW
 
-The Windows path uses fp16 mixed precision, 8-bit AdamW (bitsandbytes), and xformers. None of those are usable on Apple Silicon in 2026 (fp16/bf16 still produce NaN on MPS for SDXL, no Apple Silicon bitsandbytes build, no xformers build). The Mac path compensates with PyTorch SDPA (`sdpa = true`), MPS watermark tuning, `set_per_process_memory_fraction(0.80)`, `PYTORCH_ENABLE_MPS_FALLBACK=1`, and Adafactor + `fused_backward_pass` as the low-memory fallback.
+The Windows path uses **AdamW8bit** via bitsandbytes plus fp16 mixed precision plus xformers. None of those are usable on Apple Silicon in 2026:
 
-**Training math is identical to Windows** — only the device backend and memory strategy differ. The resulting `.safetensors` is the same kind of LoRA, produced by the same loss/optimizer math.
+- fp16 / bf16 still produce NaN losses on MPS for SDXL training.
+- bitsandbytes has no Apple Silicon build, so 8-bit AdamW is unavailable.
+- xformers has no Apple Silicon build.
+
+That means "AdamW on Mac" is necessarily 32-bit AdamW with fp32 precision — a substitute that needs roughly **2× the Windows memory footprint**. At 1024×1024 batch=2 it peaks at ~18 GiB, which is over the MPS cap of ~14.2 GiB on a 24 GB Mac (Apple reserves the rest for the OS via `recommendedMaxWorkingSetSize`).
+
+The Mac default therefore uses **Adafactor + `fused_backward_pass`**, which is the established Mac SDXL optimizer choice in the kohya_ss community since 2023. It is **not** bit-identical to Windows's AdamW8bit (and AdamW8bit isn't bit-identical to AdamW32 either — bitsandbytes is its own quantised approximation), but it produces the same kind of LoRA via a slightly different convergence trajectory. Visual quality on the resulting `.safetensors` rendered in Mac ComfyUI is the verification gate, not bitwise reproduction.
 
 ---
 
@@ -186,7 +204,7 @@ The `cpu` in the URL is misleading — Apple's official Metal docs use this same
 - No `xformers`, `bitsandbytes`, `triton-windows`, `onnxruntime-gpu`.
 - No PyInstaller `.app` bundle (deferred to v2).
 - No automated model downloader (`CoppyLora_webUI_DL.cmd` Mac equivalent — manual download per section 3).
-- Uses `AdamW` (32-bit) instead of `AdamW8bit`. AdaFactor is documented as the memory-efficient alternative.
+- Uses **Adafactor + `fused_backward_pass`** (in `config.toml`) instead of `AdamW8bit`. AdamW8bit needs bitsandbytes, which has no Apple Silicon build. A reference 32-bit AdamW config is shipped as `config_adamw_full.toml` but will OOM on essentially every Mac (see section 7).
 - Otherwise: training logic, Gradio UI, captions, base PNGs, merge/resize flow are byte-identical.
 
 ---

--- a/config.toml
+++ b/config.toml
@@ -13,10 +13,12 @@ save_model_as = "safetensors"
 lr_scheduler_num_cycles = 4
 learning_rate = 0.0001
 resolution = "1024,1024"
-train_batch_size = 2
+train_batch_size = 1
 network_dim = 16
 network_alpha = 16
-optimizer_type = "AdamW"
+optimizer_type = "Adafactor"
+optimizer_args = ["scale_parameter=False", "relative_step=False", "warmup_init=False"]
+fused_backward_pass = true
 mixed_precision = "no"
 save_precision = "bf16"
 lr_scheduler = "constant"

--- a/config_adamw_full.toml
+++ b/config_adamw_full.toml
@@ -13,12 +13,10 @@ save_model_as = "safetensors"
 lr_scheduler_num_cycles = 4
 learning_rate = 0.0001
 resolution = "1024,1024"
-train_batch_size = 1
+train_batch_size = 2
 network_dim = 16
 network_alpha = 16
-optimizer_type = "Adafactor"
-optimizer_args = ["scale_parameter=False", "relative_step=False", "warmup_init=False"]
-fused_backward_pass = true
+optimizer_type = "AdamW"
 mixed_precision = "no"
 save_precision = "bf16"
 lr_scheduler = "constant"


### PR DESCRIPTION
## Summary

First post-v2 smoke test hit MPS OOM **during VAE caching** — before the training loop even started — with the AdamW config (batch=2, fp32, 1024×1024). Peak allocation was 13.66 GiB, just under the 14.21 GiB cap; AdamW32 config genuinely does not fit on a 24 GB Mac.

This is a platform-forced choice, not a tuning issue:
- Apple's `recommendedMaxWorkingSetSize` caps MPS at ~17.7 GiB regardless of RAM total.
- The 0.80 memory-fraction cap (correctly reserving 20% for the OS) brings that to ~14.2 GiB.
- AdamW32 + fp32 + batch=2 at 1024² peaks ~18 GiB.
- Windows runs AdamW8bit via bitsandbytes; bitsandbytes has no Apple Silicon build.

So this PR makes **Adafactor + `fused_backward_pass`** the Mac default — the established kohya_ss-community Mac choice since 2023, already shipped as `config_lowmem.toml` in PR #29.

### Changes

- `config_lowmem.toml` → **renamed to `config.toml`** (the new default).
- Previous `config.toml` → **renamed to `config_adamw_full.toml`** (kept as a reference / opt-in for very-large-RAM Macs, clearly flagged as "will OOM on every <64 GB Mac").
- `README_MAC.md` sections 6, 7, 10 rewritten:
  - § 6: now documents the two configs as a table.
  - § 7: perf table marks AdamW as ❌ on 24 GB Macs.
  - § 10: Windows-diff bullet updated to "Adafactor + `fused_backward_pass`".
  - § 5: removed the stale "switch to `config_lowmem.toml`" suggestion since the default already is that profile.

No code changes. No `CoppyLora_webUI.py` changes.

## Quality firewall

The v2 quality firewall already allowed Adafactor as an opt-in alternate-convergence path. This PR just makes it the default because the prior default doesn't run. Adafactor isn't bit-identical to AdamW32 (and AdamW32 isn't bit-identical to AdamW8bit either), so verification is by **visual ComfyUI render**, not bitwise diff.

## Test plan

After merge, on M4 Pro 24 GB with hygiene checklist applied:

- [ ] Pull `mac`. Confirm `optimizer_type = "Adafactor"` in `config.toml` and `optimizer_type = "AdamW"` in `config_adamw_full.toml`.
- [ ] `./start.sh`. Drop one image. Click Train.
- [ ] Verify VAE caching completes (3/3) without OOM.
- [ ] Watch first 10 training steps — should settle ≤15 s/iter.
- [ ] Final `.safetensors` saves; renders cleanly in Mac ComfyUI.

If all pass, the next step is tagging `v1.1.0-mac` (per #33).