### PR TITLE
[mac-v2.3b] Scan external `model_dirs` (e.g. Stability Matrix on external SSD) for Base Model dropdown

### DIFF
--- a/CoppyLora_webUI.py
+++ b/CoppyLora_webUI.py
@@ -168,10 +168,97 @@ girl_mode_paths = {
 caption_dir = os.path.join(path, "caption")
 
 
+# Separator used when prefixing a filename with its source-dir tag in the
+# Base Model dropdown. Chosen to be unlikely in real safetensors filenames so
+# we can split unambiguously in resolve_base_model_path().
+_MODEL_DIR_TAG_SEP = "::"
+
+
+def _read_model_dirs_from_config():
+    """Return the user-configured list of extra model directories.
+
+    Read from `config.toml`'s `model_dirs` key. Missing/invalid entries are
+    silently dropped so a typo or an ejected external volume doesn't break
+    the dropdown.
+    """
+    try:
+        with open(config_path, "r") as f:
+            cfg = toml.load(f)
+    except (OSError, toml.TomlDecodeError):
+        return []
+    raw = cfg.get("model_dirs", [])
+    if not isinstance(raw, list):
+        return []
+    return [d for d in raw if isinstance(d, str) and d]
+
+
 # ベースモデル候補を取得する関数
 def get_base_model_options():
-    """sdxl_dir の中身を走査してファイル名のリストを返す"""
-    return [f for f in os.listdir(sdxl_dir) if f.endswith(".safetensors")]
+    """Scan sdxl_dir AND any user-configured extra dirs for *.safetensors.
+
+    Local files (in `models/SDXL/`) are listed by bare filename, matching the
+    upstream Windows behaviour. Files from any directory configured in
+    `config.toml`'s `model_dirs` list are listed as `<tag>::<filename>` where
+    `<tag>` is the basename of the configured directory (so the dropdown stays
+    short, and two directories with identical filenames don't collide).
+    `resolve_base_model_path()` reverses this back to an absolute path.
+    """
+    options = []
+    if os.path.isdir(sdxl_dir):
+        options.extend(
+            sorted(f for f in os.listdir(sdxl_dir) if f.endswith(".safetensors"))
+        )
+
+    seen_tags = {}  # tag -> count, to disambiguate same-basename dirs
+    for extra in _read_model_dirs_from_config():
+        # Expand ~ but DON'T resolve symlinks — Stability Matrix's library
+        # path can itself be a symlink and we want to preserve that.
+        expanded = os.path.expanduser(extra)
+        if not os.path.isdir(expanded):
+            continue  # Volume not mounted, path mistyped, etc. — skip silently.
+        base_tag = os.path.basename(os.path.normpath(expanded)) or "extra"
+        seen_tags[base_tag] = seen_tags.get(base_tag, 0) + 1
+        tag = base_tag if seen_tags[base_tag] == 1 else f"{base_tag}{seen_tags[base_tag]}"
+        try:
+            for f in sorted(os.listdir(expanded)):
+                if f.endswith(".safetensors"):
+                    options.append(f"{tag}{_MODEL_DIR_TAG_SEP}{f}")
+        except OSError:
+            continue
+    return options
+
+
+def resolve_base_model_path(base_model: str) -> str:
+    """Map a Base Model dropdown value back to an absolute file path.
+
+    Plain filenames (no `::` separator) are looked up under `sdxl_dir`,
+    matching the upstream behaviour. `<tag>::<filename>` forms are looked up
+    by re-scanning the configured `model_dirs` and finding the directory whose
+    basename matches `<tag>`. Same disambiguation rule as
+    `get_base_model_options()` for duplicate basenames.
+    """
+    if _MODEL_DIR_TAG_SEP in base_model:
+        tag, filename = base_model.split(_MODEL_DIR_TAG_SEP, 1)
+        seen_tags = {}
+        for extra in _read_model_dirs_from_config():
+            expanded = os.path.expanduser(extra)
+            if not os.path.isdir(expanded):
+                continue
+            base_tag = os.path.basename(os.path.normpath(expanded)) or "extra"
+            seen_tags[base_tag] = seen_tags.get(base_tag, 0) + 1
+            this_tag = (
+                base_tag if seen_tags[base_tag] == 1
+                else f"{base_tag}{seen_tags[base_tag]}"
+            )
+            if this_tag == tag:
+                return os.path.join(expanded, filename)
+        raise FileNotFoundError(
+            f"Base model '{base_model}' could not be resolved. "
+            f"Check `model_dirs` in config.toml; the source directory "
+            f"may be unmounted or removed."
+        )
+    return os.path.join(sdxl_dir, base_model)
+
 
 # base_model を選択肢として更新するための関数
 def update_base_model_options():
@@ -310,7 +397,13 @@ def simple_train(base_model, input_image_path, lora_name, mode_inputs, character
     with open(config_path, 'r') as f:
         config = toml.load(f)
 
-    base_model_path = os.path.join(sdxl_dir, base_model)
+    base_model_path = resolve_base_model_path(base_model)
+    if not os.path.exists(base_model_path):
+        raise FileNotFoundError(
+            f"Base model file not found: {base_model_path}. "
+            f"If this is from an external volume listed in `model_dirs`, "
+            f"check that the volume is mounted."
+        )
     kari_lora_name = "copi-ki-kari"
     args_dict = {
         "pretrained_model_name_or_path": base_model_path,
@@ -434,7 +527,13 @@ def detail_train(base_model, detail_lora_name, detail_base_img_path, detail_base
     with open(config_path, 'r') as f:
         config = toml.load(f)
 
-    base_model_path = os.path.join(sdxl_dir, base_model)
+    base_model_path = resolve_base_model_path(base_model)
+    if not os.path.exists(base_model_path):
+        raise FileNotFoundError(
+            f"Base model file not found: {base_model_path}. "
+            f"If this is from an external volume listed in `model_dirs`, "
+            f"check that the volume is mounted."
+        )
     base_lora_name = "copi-ki-base"
 
     args_dict = {

--- a/README_MAC.md
+++ b/README_MAC.md
@@ -87,15 +87,47 @@ Note: upstream's `CoppyLora_webUI_DL.cmd` also tries to download `copi-ki-base-f
 
 Verify any file with: `shasum -a 256 <file>`
 
+### 3.4 Using SDXL models from external volumes (e.g. Stability Matrix)
+
+If your SDXL model library lives outside the repo — Stability Matrix on an external SSD is a common Mac setup — you have two options:
+
+**Option A: symlink** (one model at a time, no config changes)
+
+```bash
+cd "models/SDXL"
+ln -s "/Volumes/YourDrive/Stability Matrix/Data/Models/StableDiffusion/some-model.safetensors" .
+```
+
+This is what `models/SDXL/animagine-xl-3.1.safetensors` does on the maintainer's machine. The dropdown picks up symlinks automatically.
+
+**Option B: configure `model_dirs` in `config.toml`** (recommended for many models)
+
+Edit `config.toml` and add directories to scan:
+
+```toml
+model_dirs = [
+    "/Volumes/Nekochan/Stability Matrix/Data/Models/StableDiffusion",
+    # add more dirs here, one per line
+]
+```
+
+The dropdown then shows entries like `StableDiffusion::aMixIllustrious_aMix.safetensors` alongside the repo-local files. The `<dirname>::<filename>` format keeps the dropdown short and prevents collisions when two directories happen to contain the same filename.
+
+**If a configured directory is unmounted** (you ejected the drive) it's silently skipped — the dropdown still loads with whatever else is available. Click "List Update" in the DetailTrain tab to re-scan after you mount/unmount.
+
 ---
 
 ## 4. Run
+
+**Double-click `Launch CoppyLora.command`** in Finder — Terminal opens, logs stream live, and your browser opens automatically when the UI is ready. Close the Terminal window to stop the app.
+
+Alternatively, run directly from Terminal:
 
 ```bash
 ./start.sh
 ```
 
-The Gradio app launches and your browser opens to <http://127.0.0.1:7860> (or the next free port if 7860 is taken).
+Either way, the Gradio app launches and your browser opens to <http://127.0.0.1:7860> (or the next free port if 7860 is taken).
 
 `./venv.sh` drops you into an interactive subshell with the venv activated, useful for running `python -c "..."` checks against the same environment.
 

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,11 @@
+# Extra directories to scan for SDXL base models (.safetensors), in addition
+# to the repo-local `models/SDXL/` folder. Files appear in the Base Model
+# dropdown as `<dirname>::<filename>`. Missing/unmounted entries are skipped
+# silently. Leave empty to use only the repo-local folder.
+# Example (Stability Matrix on a Mac with the library on an external volume):
+# model_dirs = ["/Volumes/Nekochan/Stability Matrix/Data/Models/StableDiffusion"]
+model_dirs = []
+
 pretrained_model_name_or_path = "models/animagine-xl-3.1.safetensors"
 train_data_dir = "train_data"
 output_dir = "models/LoRA"


### PR DESCRIPTION
## Summary

Mac users typically keep their SDXL model library outside the repo — Stability Matrix on an external SSD is the common setup. Until now the Base Model dropdown only saw repo-local `models/SDXL/`, so adding a model meant a manual symlink per file.

This adds a `model_dirs` list to `config.toml` (default empty). Configured directories are scanned for `.safetensors` files at startup and on "List Update" click. Files appear in the dropdown as `<dirname>::<filename>`.

## Behaviour

| Scenario | Result |
| --- | --- |
| `model_dirs = []` (default) | Dropdown shows only `models/SDXL/*.safetensors`. Identical to upstream. |
| `model_dirs = ["/Volumes/Nekochan/Stability Matrix/Data/Models/StableDiffusion"]` | Dropdown shows local files + `StableDiffusion::*.safetensors` entries from the external dir. |
| Two `model_dirs` with same basename | Disambiguated as `<name>`, `<name>2`, `<name>3`, … |
| Configured dir not mounted / typo | Silently skipped. Dropdown still loads with available files. |
| User picks a `tag::filename` entry, dir is now unmounted at training time | `FileNotFoundError` with a clear message ("…is the volume mounted?"). |
| Bogus `tag::filename` (e.g. typed by hand) | `FileNotFoundError` from the new resolver. |

## Verified on the maintainer's machine

With `model_dirs = ["/Volumes/Nekochan/Stability Matrix/Data/Models/StableDiffusion"]`:

```
options = ['animagine-xl-3.1.safetensors',
           'StableDiffusion::NoobAI-XL-Vpred-v1.0.safetensors',
           'StableDiffusion::RealVisXL_V5.0_fp16.safetensors',
           'StableDiffusion::aMixIllustrious_aMix.safetensors',
           ...11 more...]
Resolved 'StableDiffusion::NoobAI-XL-Vpred-v1.0.safetensors'
       → /Volumes/Nekochan/Stability Matrix/Data/Models/StableDiffusion/NoobAI-XL-Vpred-v1.0.safetensors
       (file exists ✓)
```

## Files

- `CoppyLora_webUI.py`:
  - New `_MODEL_DIR_TAG_SEP = "::"` constant.
  - New `_read_model_dirs_from_config()` helper.
  - `get_base_model_options()` rewritten — local files keep their bare-filename listing; external files prefixed with `<dirname>::`.
  - New `resolve_base_model_path()` — reverses dropdown values back to absolute paths.
  - `simple_train` and `detail_train` now use the resolver and check `os.path.exists()` before handing off to sd-scripts (previously a missing file produced a cryptic checkpoint-load traceback).
- `config.toml`: new `model_dirs = []` field with an inline comment showing the Stability Matrix example.
- `README_MAC.md`: new section 3.4 ("Using SDXL models from external volumes") documenting both Option A (symlink, one-at-a-time) and Option B (`model_dirs`, recommended for many models).

## Quality firewall

This is a UI / config-routing change. **No training-math, no optimizer, no precision, no scheduler changes.** v2.2's AdamW + VAE tiling + memory-fraction setup is untouched.

## Test plan

- [x] Unit-style test of `get_base_model_options()` and `resolve_base_model_path()` in isolation: passes for empty config, plain resolver, with `/Volumes/Nekochan/...` mounted, and bogus-tag → `FileNotFoundError`.
- [x] `python -c "import ast; ast.parse(open('CoppyLora_webUI.py').read())"` — syntax OK.
- [ ] **End-to-end**: launch the app, set `model_dirs = ["/Volumes/Nekochan/Stability Matrix/Data/Models/StableDiffusion"]`, pick an external model in the DetailTrain dropdown, click Train (or just SimpleTrain), confirm training log shows `pretrained_model_name_or_path = /Volumes/Nekochan/...` and the run starts. (Maintainer to do as part of normal use.)

## Related

Companion to v2.3a (DetailTrain smoke test on Mac), which is functionally independent and will ship as its own PR after the user finishes a ~100-min DetailTrain run.