### PR TITLE
[mac-v2.3a] Release MPS cache before each trainer.train() — fixes DetailTrain UNet-load OOM

### DIFF
--- a/CoppyLora_webUI.py
+++ b/CoppyLora_webUI.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import shutil
 import gradio as gr
@@ -94,6 +95,28 @@ if DEFAULT_DEVICE == "mps":
         AutoencoderKL.__init__ = _patched_autoencoderkl_init
     except ImportError:
         pass
+
+
+def _release_mps_memory():
+    """Release Python references and tell MPS to drop its cached blocks.
+
+    PyTorch's MPS allocator caches freed blocks for reuse and never
+    automatically returns them to the OS. The Gradio process is long-lived
+    (a single click on Train can fire many minutes after Tagger / Caption /
+    a previous training), so MPS memory accumulates from earlier operations
+    and the next training step starts already 4-8 GB into the 14.2 GiB cap.
+
+    Calling `gc.collect()` first drops any Python-side dead references that
+    still pin tensors; then `torch.mps.empty_cache()` returns the cached
+    MPS blocks. On Mac, this is the only safe handle we have for
+    "reset between operations". No-op on non-MPS devices.
+    """
+    gc.collect()
+    if DEFAULT_DEVICE == "mps":
+        try:
+            torch.mps.empty_cache()
+        except (AttributeError, RuntimeError):
+            pass
 
 
 # ログでエラーが出るので、念のため環境変数を設定
@@ -450,6 +473,12 @@ def simple_train(base_model, input_image_path, lora_name, mode_inputs, character
     TextEncoderOutputsCachingStrategy._strategy = None
     LatentsCachingStrategy._strategy = None
 
+    # Drop any cached MPS blocks left over from earlier Gradio operations
+    # (a previous train, the Tagger ONNX session, sample-image renders,
+    # etc.). Without this, the next checkpoint load can hit OOM at the
+    # 14.2 GiB cap because the cache still holds 4-8 GiB from before.
+    _release_mps_memory()
+
     parser = sdxl_train_network.setup_parser()
     args = parser.parse_args()
     sdxl_train_network.train_util.verify_command_line_training_args(args)
@@ -581,6 +610,12 @@ def detail_train(base_model, detail_lora_name, detail_base_img_path, detail_base
     TextEncoderOutputsCachingStrategy._strategy = None
     LatentsCachingStrategy._strategy = None
 
+    # Drop any cached MPS blocks left over from earlier Gradio operations
+    # (a previous train, the Tagger ONNX session, sample-image renders,
+    # etc.). Without this, the next checkpoint load can hit OOM at the
+    # 14.2 GiB cap because the cache still holds 4-8 GiB from before.
+    _release_mps_memory()
+
     parser = sdxl_train_network.setup_parser()
     args = parser.parse_args()
     sdxl_train_network.train_util.verify_command_line_training_args(args)
@@ -648,6 +683,12 @@ def detail_train(base_model, detail_lora_name, detail_base_img_path, detail_base
     TextEncodingStrategy._strategy = None
     TextEncoderOutputsCachingStrategy._strategy = None
     LatentsCachingStrategy._strategy = None
+
+    # Drop any cached MPS blocks left over from earlier Gradio operations
+    # (a previous train, the Tagger ONNX session, sample-image renders,
+    # etc.). Without this, the next checkpoint load can hit OOM at the
+    # 14.2 GiB cap because the cache still holds 4-8 GiB from before.
+    _release_mps_memory()
 
     parser = sdxl_train_network.setup_parser()
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

DetailTrain (and any second click of SimpleTrain in the same Gradio session) hits `MPS backend out of memory` while *loading the U-Net*, before sd-scripts has done any real work. Allocated ≈ 14.17 GiB of the 14.21 GiB cap, with 50 MiB still needed.

## Root cause

PyTorch's MPS allocator caches freed blocks for reuse and never returns them to the OS automatically. The Gradio process is long-lived — Tagger ONNX, previous SimpleTrain, sample-image renders, etc. all leave tensors in the MPS cache. Python-side strategy resets (`TokenizeStrategy._strategy = None`, `LatentsCachingStrategy._strategy = None`, …) drop sd-scripts' references but don't tell MPS to drop its cache. By the time the user clicks Train, the cap is already mostly full.

## Fix

A small `_release_mps_memory()` helper:

```python
def _release_mps_memory():
    gc.collect()
    if DEFAULT_DEVICE == "mps":
        try:
            torch.mps.empty_cache()
        except (AttributeError, RuntimeError):
            pass
```

Called right after each strategy-reset block. Three sites:
1. `simple_train` (one training)
2. `detail_train` pass 1 (base LoRA)
3. `detail_train` pass 2 (kari LoRA)

No-op on non-MPS devices. **Zero training-math impact** — this is purely an allocator hint.

## Quality firewall

- No loss / optimizer / gradient / scheduler / noise change.
- No model-file change.
- `gc.collect()` + `torch.mps.empty_cache()` are documented PyTorch APIs for memory management.

## Test plan

- [x] Syntax check passes (`ast.parse`).
- [x] Three insertion points verified (one per `trainer.train(args)` site).
- [ ] Live: DetailTrain with the external Stability Matrix model now loads the U-Net without OOM, both training passes complete, the merge + SVD-resize finishes, the final `.safetensors` saves. (Maintainer to run after merge.)

## Follow-up if this isn't enough

If 0.80 memory_fraction is still too tight even with a clean cache, next escalation is bumping to 0.85 in `CoppyLora_webUI.py`. Try this PR first.

## Related

Companion to v2.3b (#33, merged) — the `model_dirs` external-volume scan. Together these complete the v2.3 plan.