### PR TITLE
[mac-v2.3c] Gradio 4: replace deprecated `gr.Dropdown.update(...)`

### DIFF
--- a/CoppyLora_webUI.py
+++ b/CoppyLora_webUI.py
@@ -285,7 +285,11 @@ def resolve_base_model_path(base_model: str) -> str:
 
 # base_model を選択肢として更新するための関数
 def update_base_model_options():
-    return gr.Dropdown.update(choices=get_base_model_options())
+    # Gradio 4.x replaced the old `gr.Dropdown.update(...)` classmethod with
+    # "just construct a fresh component and return it" — same effect, simpler
+    # API. Upstream Windows still uses the 3.x form (and an open upstream PR
+    # tracks it), so we keep this on the Mac branch for now.
+    return gr.Dropdown(choices=get_base_model_options())
 
 def find_free_port(start_port=7860):
     """指定したポートから開始して空いているポートを見つけて返す関数"""


### PR DESCRIPTION
## Summary

The "List Update" button on the DetailTrain tab raised `AttributeError: type object 'Dropdown' has no attribute 'update'` the moment a user clicked it. This is a pre-existing upstream bug exposed by v2.3b — when external `model_dirs` are configured, users actually have a reason to click List Update (to pick up newly-mounted external volumes).

**Cause:** Gradio 4.x removed the `gr.Dropdown.update(...)` classmethod. The replacement is "just construct a fresh component and return it." Upstream Windows still ships the 3.x form (open upstream PR tracks it).

```diff
-    return gr.Dropdown.update(choices=get_base_model_options())
+    return gr.Dropdown(choices=get_base_model_options())
```

## Verified

Tested live during the DetailTrain smoke test (the `_release_mps_memory()` validation run): clicking List Update no longer raises, the dropdown re-scans correctly with `model_dirs` content.

## Quality firewall

UI-only fix, zero training-math impact. Mac-only — keeps the upstream Windows path bit-for-bit identical. If upstream merges the equivalent PR we can drop this.

## Related

Closes the immediate UI bug exposed by v2.3b (#33). Together with v2.3a (#34), v2.3 is now fully verified end-to-end: SimpleTrain ✓, DetailTrain ✓ (~70 min, loss 0.052/0.063, Frobenius retention 99.64%).